### PR TITLE
Seek to beginning of all partitions and store objects in db

### DIFF
--- a/naiserator-dev.yaml
+++ b/naiserator-dev.yaml
@@ -9,7 +9,7 @@ spec:
   image: {{ image }}
   replicas:
     min: 1
-    max: 2
+    max: 1
     cpuThresholdPercentage: 90
   port: 8080
   liveness:

--- a/naiserator-prod.yaml
+++ b/naiserator-prod.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   image: {{ image }}
   replicas:
-    min: 2
-    max: 4
+    min: 1
+    max: 1
     cpuThresholdPercentage: 90
   port: 8080
   liveness:

--- a/src/main/kotlin/no/nav/syfo/clients/KafkaConsumers.kt
+++ b/src/main/kotlin/no/nav/syfo/clients/KafkaConsumers.kt
@@ -4,8 +4,10 @@ import no.nav.syfo.Environment
 import no.nav.syfo.kafka.KafkaCredentials
 import no.nav.syfo.kafka.loadBaseConfig
 import no.nav.syfo.kafka.toConsumerConfig
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.serialization.StringDeserializer
+import java.util.*
 
 class KafkaConsumers(env: Environment, vaultSecrets: KafkaCredentials) {
     private val kafkaBaseConfig = loadBaseConfig(env, vaultSecrets)
@@ -14,5 +16,10 @@ class KafkaConsumers(env: Environment, vaultSecrets: KafkaCredentials) {
         valueDeserializer = StringDeserializer::class
     )
 
-    val kafkaConsumerSmReg = KafkaConsumer<String, String>(properties)
+    private fun Properties.addExtraProps(): Properties {
+        this.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+        return this
+    }
+
+    val kafkaConsumerSmReg = KafkaConsumer<String, String>(properties.addExtraProps())
 }


### PR DESCRIPTION
Når én eller flere partitions blir satt på consumeren, seekToBeginning på alle som ikke er lest fra før.
Deretter lagre alle vi resetter, slik at de ikke leses fra start på nytt (når vi deployer neste gang vil den "døende" podden få tildelt nye partitions, og hadde resatt offsett enda en gang hvis vi ikke har sjekk på hvilke som allerede er resatt).
Før denne merges og vi deployer til prod og preprod, må dben tømmes i preprod, ellers vil vi få dobbelt opp med data der.
Etter merge og prod/preprod er fylt med all data fra kafka, kan vi dytte ut en ny versjon hvor vi har fjernet seekToBeginning-koden (her kommer listen med "allerede resatte partitions" inn i bildet). Deretter vil appen fortsette med nyeste offsett og lagre nye elementer i db etter hvert som de kommer inn.

Jeg vet ikke hvor lang tid det vil ta å lese inn alle data; det gikk fort i preprod, men der er det bare noen få tusen elementer til sammen.