### PR TITLE
Use new consumer groupID, read all kafka from beginning

### DIFF
--- a/naiserator-dev.yaml
+++ b/naiserator-dev.yaml
@@ -9,7 +9,7 @@ spec:
   image: {{ image }}
   replicas:
     min: 1
-    max: 1
+    max: 2
     cpuThresholdPercentage: 90
   port: 8080
   liveness:

--- a/naiserator-prod.yaml
+++ b/naiserator-prod.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   image: {{ image }}
   replicas:
-    min: 1
-    max: 1
+    min: 2
+    max: 4
     cpuThresholdPercentage: 90
   port: 8080
   liveness:

--- a/src/main/kotlin/no/nav/syfo/clients/KafkaConsumers.kt
+++ b/src/main/kotlin/no/nav/syfo/clients/KafkaConsumers.kt
@@ -12,7 +12,7 @@ import java.util.*
 class KafkaConsumers(env: Environment, vaultSecrets: KafkaCredentials) {
     private val kafkaBaseConfig = loadBaseConfig(env, vaultSecrets)
     private val properties = kafkaBaseConfig.toConsumerConfig(
-        "${env.applicationName}-consumer",
+        "${env.applicationName}-consumer2",
         valueDeserializer = StringDeserializer::class
     )
 


### PR DESCRIPTION
Mer logging, så vi forhåpentligvis har litt mer oversikt over hvor langt i løypa vi har kommet.
Øk Antall pods i prod/preprod.

Ny metode: Bruk ny consumer groupID. Kafka lagrer offset basert på denne IDen, så når vi bruker en ny, vil kafka bruke en default offset som vi har satt til å være 0 (earliest). Deretter leser den og lagrer meldinger som vanlig, og det skal kunne håndtere flere pods, og restarts.
Det kan bli en del støy i loggene når man er ferdig med en partisjon, fordi den for alle nye meldinger vil logge "er på endOffsett". For å sjekke at alt er ferdig, må man se på listen over partisjoner, og sjekke om det har blitt logget endOffsett på alle.

Denne koden skal kunne leve fint etter innlesing, uten av vi trenger en ny commit der vi fjerner noe. Det kan være fornuftig å fjerne/endre loggingen da!