### PR TITLE
Replace dependency syfosm-common-kafka

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,6 @@ val logbackVersion = "1.2.3"
 val logstashEncoderVersion = "6.3"
 val postgresVersion = "42.2.13"
 val prometheusVersion = "0.8.1"
-val smCommonVersion = "1.0.22"
 val vaultJavaDriveVersion = "3.1.0"
 
 plugins {
@@ -43,7 +42,6 @@ dependencies {
     implementation("com.bettercloud:vault-java-driver:$vaultJavaDriveVersion")
 
     implementation("org.apache.kafka:kafka_2.12:$kafkaVersion")
-    implementation("no.nav.syfo.sm:syfosm-common-kafka:$smCommonVersion")
 }
 
 tasks {

--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -1,13 +1,10 @@
 package no.nav.syfo
 
-import no.nav.syfo.kafka.KafkaConfig
-import no.nav.syfo.kafka.KafkaCredentials
-
 data class Environment(
     val applicationName: String = getEnvVar("NAIS_APP_NAME", "isprediksjon"),
     val applicationPort: Int = getEnvVar("APPLICATION_PORT", "8080").toInt(),
 
-    override val kafkaBootstrapServers: String = getEnvVar("KAFKA_BOOTSTRAP_SERVERS_URL"),
+    val kafkaBootstrapServers: String = getEnvVar("KAFKA_BOOTSTRAP_SERVERS_URL"),
     val sm2013ManuellBehandlingTopic: String = getEnvVar("KAFKA_SM2013_MANUELL_BEHANDLING", "privat-syfo-sm2013-manuellBehandling"),
     val sm2013AutomatiskBehandlingTopic: String = getEnvVar("KAFKA_SM2013_AUTOMATISK_BEHANDLING_TOPIC", "privat-syfo-sm2013-automatiskBehandling"),
     val smregisterRecievedSykmeldingBackupTopic: String = getEnvVar("KAFKA_SMREGISTER_RECIEVED_SYKMELDING_BACKUP_TOPIC", "privat-syfosmregister-received-sykmelding-backup"),
@@ -22,15 +19,12 @@ data class Environment(
     val isprediksjonDBURL: String = getEnvVar("ISPREDIKSJON_DB_URL"),
 
     val developmentMode: Boolean = getEnvVar("DEVELOPMENT_MODE", "false").toBoolean()
-) : KafkaConfig
+)
 
 data class VaultSecrets(
     val serviceuserUsername: String,
     val serviceuserPassword: String
-) : KafkaCredentials {
-    override val kafkaUsername: String = serviceuserUsername
-    override val kafkaPassword: String = serviceuserPassword
-}
+)
 
 fun getEnvVar(varName: String, defaultValue: String? = null) =
     System.getenv(varName) ?: defaultValue ?: throw RuntimeException("Missing required variable \"$varName\"")

--- a/src/main/kotlin/no/nav/syfo/clients/KafkaConsumers.kt
+++ b/src/main/kotlin/no/nav/syfo/clients/KafkaConsumers.kt
@@ -1,25 +1,30 @@
 package no.nav.syfo.clients
 
 import no.nav.syfo.Environment
-import no.nav.syfo.kafka.KafkaCredentials
-import no.nav.syfo.kafka.loadBaseConfig
-import no.nav.syfo.kafka.toConsumerConfig
+import no.nav.syfo.VaultSecrets
+import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.KafkaConsumer
-import org.apache.kafka.common.serialization.StringDeserializer
 import java.util.*
 
-class KafkaConsumers(env: Environment, vaultSecrets: KafkaCredentials) {
-    private val kafkaBaseConfig = loadBaseConfig(env, vaultSecrets)
-    private val properties = kafkaBaseConfig.toConsumerConfig(
-        "${env.applicationName}-consumer2",
-        valueDeserializer = StringDeserializer::class
-    )
+class KafkaConsumers(
+    env: Environment,
+    vaultSecrets: VaultSecrets
+) {
+    private val properties = Properties().apply {
+        this[ConsumerConfig.GROUP_ID_CONFIG] = "${env.applicationName}-consumer2"
+        this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+        this[CommonClientConfigs.RETRIES_CONFIG] = "2"
+        this["acks"] = "all"
+        this["security.protocol"] = "SASL_SSL"
+        this["sasl.mechanism"] = "PLAIN"
+        this["schema.registry.url"] = "http://kafka-schema-registry.tpa:8081"
+        this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = "org.apache.kafka.common.serialization.StringDeserializer"
+        this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = "org.apache.kafka.common.serialization.StringDeserializer"
 
-    private fun Properties.addExtraProps(): Properties {
-        this.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-        return this
+        this["sasl.jaas.config"] = "org.apache.kafka.common.security.plain.PlainLoginModule required " +
+            "username=\"${vaultSecrets.serviceuserUsername}\" password=\"${vaultSecrets.serviceuserPassword}\";"
+        this[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = env.kafkaBootstrapServers
     }
-
-    val kafkaConsumerSmReg = KafkaConsumer<String, String>(properties.addExtraProps())
+    val kafkaConsumerSmReg = KafkaConsumer<String, String>(properties)
 }


### PR DESCRIPTION
Remove the abstracted creation of properties for KafkaConsumer with syfosm-common-kafka and instead create proprties  directly for KafkaConsumer. This change removes a redundant package dependency and ensures that the correct set of properties are set for the KafkaConsumer.