### PR TITLE
Change AUTO_OFFSET_RESET_CONFIG of OppfolgingstilfelleConsumer to latest

### DIFF
--- a/src/main/kotlin/no/nav/syfo/KafkaModule.kt
+++ b/src/main/kotlin/no/nav/syfo/KafkaModule.kt
@@ -178,6 +178,7 @@ suspend fun pollAndProcessOppfolgingstilfelleTopic(
             oppfolgingstilfelleService.receiveOppfolgingstilfelle(oppfolgingstilfellePeker, callId)
         }
     }
+    kafkaConsumer.commitSync()
     delay(100)
 }
 

--- a/src/main/kotlin/no/nav/syfo/clients/KafkaConsumers.kt
+++ b/src/main/kotlin/no/nav/syfo/clients/KafkaConsumers.kt
@@ -7,7 +7,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import java.util.*
 
-fun kafkaConsumerProperties(
+fun kafkaConsumerSmregProperties(
     env: Environment,
     vaultSecrets: VaultSecrets
 ) = Properties().apply {
@@ -26,10 +26,30 @@ fun kafkaConsumerProperties(
     this[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = env.kafkaBootstrapServers
 }
 
+fun kafkaConsumerOppfolgingstilfelleProperties(
+    env: Environment,
+    vaultSecrets: VaultSecrets
+) = Properties().apply {
+    this[ConsumerConfig.GROUP_ID_CONFIG] = "${env.applicationName}-consumer2"
+    this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "latest"
+    this[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = false
+    this[CommonClientConfigs.RETRIES_CONFIG] = "2"
+    this["acks"] = "all"
+    this["security.protocol"] = "SASL_SSL"
+    this["sasl.mechanism"] = "PLAIN"
+    this["schema.registry.url"] = "http://kafka-schema-registry.tpa:8081"
+    this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = "org.apache.kafka.common.serialization.StringDeserializer"
+    this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = "org.apache.kafka.common.serialization.StringDeserializer"
+
+    this["sasl.jaas.config"] = "org.apache.kafka.common.security.plain.PlainLoginModule required " +
+        "username=\"${vaultSecrets.serviceuserUsername}\" password=\"${vaultSecrets.serviceuserPassword}\";"
+    this[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = env.kafkaBootstrapServers
+}
+
 class KafkaConsumers(
     env: Environment,
     vaultSecrets: VaultSecrets
 ) {
-    val kafkaConsumerOppfolgingstilfelle = KafkaConsumer<String, String>(kafkaConsumerProperties(env, vaultSecrets))
-    val kafkaConsumerSmReg = KafkaConsumer<String, String>(kafkaConsumerProperties(env, vaultSecrets))
+    val kafkaConsumerOppfolgingstilfelle = KafkaConsumer<String, String>(kafkaConsumerOppfolgingstilfelleProperties(env, vaultSecrets))
+    val kafkaConsumerSmReg = KafkaConsumer<String, String>(kafkaConsumerSmregProperties(env, vaultSecrets))
 }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/KafkaOppfolgingstilfelleSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/KafkaOppfolgingstilfelleSpek.kt
@@ -8,12 +8,13 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.ktor.server.testing.*
 import io.ktor.util.*
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.common.KafkaEnvironment
 import no.nav.syfo.clients.aktor.AktorService
 import no.nav.syfo.clients.aktor.AktorregisterClient
-import no.nav.syfo.clients.kafkaConsumerProperties
+import no.nav.syfo.clients.kafkaConsumerOppfolgingstilfelleProperties
 import no.nav.syfo.clients.sts.StsRestClient
 import no.nav.syfo.clients.syketilfelle.SyketilfelleClient
 import no.nav.syfo.pollAndProcessOppfolgingstilfelleTopic
@@ -105,7 +106,7 @@ object KafkaOppfolgingstilfelleSpek : Spek({
         }
 
         describe("Read and store PPrediksjonInput") {
-            val consumerPropertiesOppfolgingstilfelle = kafkaConsumerProperties(env, testutil.vaultSecrets)
+            val consumerPropertiesOppfolgingstilfelle = kafkaConsumerOppfolgingstilfelleProperties(env, testutil.vaultSecrets)
                 .overrideForTest()
 
             val kafkaConsumerOppfolgingstilfelle = KafkaConsumer<String, String>(consumerPropertiesOppfolgingstilfelle)
@@ -128,6 +129,7 @@ object KafkaOppfolgingstilfelleSpek : Spek({
                 )
 
                 val mockConsumer = mockk<KafkaConsumer<String, String>>()
+                justRun { mockConsumer.commitSync() }
                 every { mockConsumer.poll(Duration.ofMillis(0)) } returns ConsumerRecords(
                     mapOf(oppfolgingstilfelleTopicPartition to listOf(oppfolgingstilfellePekerRecord))
                 )

--- a/src/test/kotlin/no/nav/syfo/persistence/HandleReceivedMessageSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/persistence/HandleReceivedMessageSpek.kt
@@ -6,7 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import no.nav.common.KafkaEnvironment
-import no.nav.syfo.clients.kafkaConsumerProperties
+import no.nav.syfo.clients.kafkaConsumerSmregProperties
 import org.amshove.kluent.shouldBeEqualTo
 import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
@@ -72,7 +72,7 @@ object HandleReceivedMessageSpek : Spek({
         with(TestApplicationEngine()) {
             start()
 
-            val consumerPropertiesOversikthendelse = kafkaConsumerProperties(env, vaultSecrets)
+            val consumerPropertiesOversikthendelse = kafkaConsumerSmregProperties(env, vaultSecrets)
                 .overrideForTest()
                 .apply {
                     put("specific.avro.reader", false)


### PR DESCRIPTION
If there is  no initial offset in Kafka or if the current offset does not exist any more on the server, then the consumer will begin at the latest offset, not the earliest. This is to prevent consuming multiple times in case of failure and potential skipped message are torable for isprediksjon.
Also enable manual commit for topic Oppfolgingstilfelle.