### PR TITLE
Add test for PrediksjonApi

### DIFF
--- a/src/main/kotlin/no/nav/syfo/Bootstrap.kt
+++ b/src/main/kotlin/no/nav/syfo/Bootstrap.kt
@@ -55,11 +55,15 @@ fun main() {
 
             module {
                 auth(wellKnown, listOf(env.loginserviceClientId))
-                serverModule(applicationState, env)
                 databaseModule(
                     applicationState,
                     env,
                     vaultCredentialService
+                )
+                serverModule(
+                    applicationState,
+                    database,
+                    env
                 )
                 kafkaModule(
                     applicationState,

--- a/src/main/kotlin/no/nav/syfo/ServerModule.kt
+++ b/src/main/kotlin/no/nav/syfo/ServerModule.kt
@@ -7,9 +7,11 @@ import no.nav.syfo.application.api.registerNaisApi
 import no.nav.syfo.application.api.registerPrediksjon
 import no.nav.syfo.application.installContentNegotiation
 import no.nav.syfo.clients.Tilgangskontroll
+import no.nav.syfo.database.DatabaseInterface
 
 fun Application.serverModule(
     applicationState: ApplicationState,
+    database: DatabaseInterface,
     env: Environment
 ) {
     log.info("Initialization of server module starting")
@@ -18,7 +20,10 @@ fun Application.serverModule(
 
     routing {
         registerNaisApi(applicationState)
-        registerPrediksjon(Tilgangskontroll(env.tilgangskontrollUrl))
+        registerPrediksjon(
+            database,
+            Tilgangskontroll(env.tilgangskontrollUrl)
+        )
     }
     log.info("Initialization of server module done")
 }

--- a/src/main/kotlin/no/nav/syfo/application/api/PrediksjonApi.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/PrediksjonApi.kt
@@ -5,19 +5,22 @@ import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import no.nav.syfo.clients.Tilgangskontroll
-import no.nav.syfo.database
+import no.nav.syfo.database.DatabaseInterface
 import no.nav.syfo.domain.Fodselsnummer
 import no.nav.syfo.prediksjon.getPrediksjon
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-val log: Logger = LoggerFactory.getLogger("no.nav.syfo.application.api")
+private val log: Logger = LoggerFactory.getLogger("no.nav.syfo.application.api")
 
 const val apiBasePath = "/api/v1"
 const val apiPrediksjon = "/prediksjon"
 const val NAV_PERSONIDENT_HEADER = "nav-personident"
 
-fun Route.registerPrediksjon(tilgangskontroll: Tilgangskontroll) {
+fun Route.registerPrediksjon(
+    database: DatabaseInterface,
+    tilgangskontroll: Tilgangskontroll
+) {
 
     route(apiBasePath) {
         get(apiPrediksjon) {

--- a/src/test/kotlin/no/nav/syfo/application/api/PrediksjonApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/api/PrediksjonApiSpek.kt
@@ -1,0 +1,152 @@
+package no.nav.syfo.application.api
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.ktor.http.*
+import io.ktor.http.HttpHeaders.Authorization
+import io.ktor.server.testing.*
+import no.nav.syfo.application.ApplicationState
+import no.nav.syfo.prediksjon.PrediksjonOutput
+import no.nav.syfo.prediksjon.createPrediksjonOutputTest
+import no.nav.syfo.serverModule
+import no.nav.syfo.util.bearerHeader
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import testutil.TestDB
+import testutil.UserConstants.ARBEIDSTAKER_FNR
+import testutil.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
+import testutil.dropData
+import testutil.generator.generatePrediksjonOutput
+import testutil.getRandomPort
+import testutil.mock.VeilederTilgangskontrollMock
+import testutil.testEnvironment
+
+class PrediksjonApiSpek : Spek({
+    val objectMapper: ObjectMapper = ObjectMapper().apply {
+        registerKotlinModule()
+        registerModule(JavaTimeModule())
+        configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+    }
+
+    describe("PrediksjonApiSpek") {
+
+        with(TestApplicationEngine()) {
+            start()
+
+            val tilgangskontrollMock = VeilederTilgangskontrollMock()
+
+            val applicationState = ApplicationState(
+                alive = true,
+                ready = true
+            )
+
+            val database = TestDB()
+
+            val environment = testEnvironment(
+                getRandomPort(),
+                "",
+                tilgangskontrollUrl = tilgangskontrollMock.url
+            )
+
+            application.serverModule(
+                applicationState = applicationState,
+                database = database,
+                env = environment,
+            )
+
+            beforeGroup {
+                tilgangskontrollMock.server.start()
+            }
+
+            afterEachTest {
+                database.connection.dropData("prediksjon_output")
+            }
+
+            afterGroup {
+                tilgangskontrollMock.server.stop(1L, 10L)
+
+                database.stop()
+            }
+
+            val url = "$apiBasePath$apiPrediksjon"
+            describe("Successful get") {
+                it("should return DialogmoteList if request is successful") {
+                    database.createPrediksjonOutputTest(
+                        generatePrediksjonOutput,
+                        1
+                    )
+
+                    with(
+                        handleRequest(HttpMethod.Get, url) {
+                            addHeader(Authorization, bearerHeader("validToken"))
+                            addHeader(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_FNR.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
+
+                        val prediksjonList = objectMapper.readValue<List<PrediksjonOutput>>(response.content!!)
+
+                        prediksjonList.size shouldBeEqualTo 1
+
+                        val prediksjon = prediksjonList[0]
+                        prediksjon.fnr shouldBeEqualTo ARBEIDSTAKER_FNR
+                    }
+                }
+
+                it("should return empty list if request is successful, but no prediksjoner exists on given person") {
+                    with(
+                        handleRequest(HttpMethod.Get, url) {
+                            addHeader(Authorization, bearerHeader("validToken"))
+                            addHeader(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_FNR.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
+
+                        val prediksjonList = objectMapper.readValue<List<PrediksjonOutput>>(response.content!!)
+
+                        prediksjonList.size shouldBeEqualTo 0
+                    }
+                }
+            }
+
+            describe("Failing get") {
+                it("Should return BadRequest if no token is given as header") {
+                    with(
+                        handleRequest(HttpMethod.Get, url) {
+                            addHeader(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_FNR.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                    }
+                }
+
+                it("Should return BadRequest if no fnr is given as header") {
+                    with(
+                        handleRequest(HttpMethod.Get, url) {
+                            addHeader(Authorization, bearerHeader("validToken"))
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                    }
+                }
+
+                it("Should return 403 Forbidden if veileder doesn't have access to user") {
+                    with(
+                        handleRequest(HttpMethod.Get, url) {
+                            addHeader(Authorization, bearerHeader("validToken"))
+                            addHeader(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_VEILEDER_NO_ACCESS.value)
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.Forbidden
+                    }
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/prediksjon/PrediksjonOutputSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/prediksjon/PrediksjonOutputSpek.kt
@@ -5,16 +5,15 @@ import io.ktor.server.testing.*
 import io.mockk.unmockkAll
 import no.nav.syfo.database.DatabaseInterface
 import no.nav.syfo.database.toList
-import no.nav.syfo.domain.AktorId
-import no.nav.syfo.domain.Fodselsnummer
 import org.amshove.kluent.shouldBeEqualTo
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import testutil.TestDB
+import testutil.UserConstants.ARBEIDSTAKER_FNR
+import testutil.generator.generatePrediksjonOutput
 import java.sql.SQLException
 import java.sql.Timestamp
 import java.time.Instant
-import java.time.OffsetDateTime
 import java.util.*
 
 object PrediksjonOutputSpek : Spek({
@@ -32,24 +31,12 @@ object PrediksjonOutputSpek : Spek({
         }
 
         describe("Should store and get from prediksjon_output") {
-            val fnr = Fodselsnummer("11111111111")
-            val aktorid = AktorId("2222222222222")
-
             database.createPrediksjonOutputTest(
-                PrediksjonOutput(
-                    fnr,
-                    aktorid,
-                    OffsetDateTime.now(),
-                    OffsetDateTime.now(),
-                    OffsetDateTime.now(),
-                    "OK",
-                    0.95f,
-                    ForklaringFrontend(listOf("diagnosis", "md"), listOf("grad", "time", "hist"))
-                ),
+                generatePrediksjonOutput,
                 1
             )
             it("Should return 1 prediksjon ") {
-                val prediksjonList = database.getPrediksjon(fnr)
+                val prediksjonList = database.getPrediksjon(ARBEIDSTAKER_FNR)
 
                 prediksjonList.size shouldBeEqualTo 1
             }

--- a/src/test/kotlin/testutil/TestEnvironment.kt
+++ b/src/test/kotlin/testutil/TestEnvironment.kt
@@ -5,7 +5,11 @@ import no.nav.syfo.VaultSecrets
 import java.net.ServerSocket
 import java.util.*
 
-fun testEnvironment(port: Int, kafkaBootstrapServers: String) = Environment(
+fun testEnvironment(
+    port: Int,
+    kafkaBootstrapServers: String,
+    tilgangskontrollUrl: String = ""
+) = Environment(
     applicationName = "isprediksjon",
     applicationPort = port,
     kafkaBootstrapServers = kafkaBootstrapServers,
@@ -23,7 +27,9 @@ fun testEnvironment(port: Int, kafkaBootstrapServers: String) = Environment(
     stsRestUrl = "http://stsrest",
     loginserviceClientId = "1234",
     aadDiscoveryUrl = "",
-    syketilfelleUrl = "http://syfosyketilfelle:0001"
+    syketilfelleUrl = "http://syfosyketilfelle:0001",
+    developmentMode = true,
+    tilgangskontrollUrl = tilgangskontrollUrl
 )
 
 val vaultSecrets = VaultSecrets(

--- a/src/test/kotlin/testutil/UserConstants.kt
+++ b/src/test/kotlin/testutil/UserConstants.kt
@@ -5,6 +5,7 @@ import no.nav.syfo.domain.Fodselsnummer
 
 object UserConstants {
     val ARBEIDSTAKER_FNR = Fodselsnummer("12345678912")
+    val ARBEIDSTAKER_VEILEDER_NO_ACCESS = Fodselsnummer(ARBEIDSTAKER_FNR.value.replace("2", "1"))
     val ARBEIDSTAKER_AKTORID = AktorId("1234567891201")
     val ARBEIDSTAKER_AKTORID_FINNES_IKKE = AktorId("1234567891202")
     const val VIRKSOMHETSNUMMER = "123456789"

--- a/src/test/kotlin/testutil/generator/PrediksjonOutputGenerator.kt
+++ b/src/test/kotlin/testutil/generator/PrediksjonOutputGenerator.kt
@@ -1,0 +1,19 @@
+package testutil.generator
+
+import no.nav.syfo.prediksjon.ForklaringFrontend
+import no.nav.syfo.prediksjon.PrediksjonOutput
+import testutil.UserConstants.ARBEIDSTAKER_AKTORID
+import testutil.UserConstants.ARBEIDSTAKER_FNR
+import java.time.OffsetDateTime
+
+val generatePrediksjonOutput =
+    PrediksjonOutput(
+        ARBEIDSTAKER_FNR,
+        ARBEIDSTAKER_AKTORID,
+        OffsetDateTime.now(),
+        OffsetDateTime.now(),
+        OffsetDateTime.now(),
+        "OK",
+        0.95f,
+        ForklaringFrontend(listOf("diagnosis", "md"), listOf("grad", "time", "hist"))
+    )

--- a/src/test/kotlin/testutil/mock/VeilederTilgangskontrollMock.kt
+++ b/src/test/kotlin/testutil/mock/VeilederTilgangskontrollMock.kt
@@ -1,0 +1,63 @@
+package testutil.mock
+
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.ktor.application.*
+import io.ktor.features.*
+import io.ktor.http.*
+import io.ktor.jackson.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import no.nav.syfo.clients.Tilgangskontroll.Tilgang
+import testutil.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
+import testutil.getRandomPort
+
+class VeilederTilgangskontrollMock {
+    private val port = getRandomPort()
+    val url = "http://localhost:$port"
+    val tilgangFalse = Tilgang(
+        false,
+        ""
+    )
+    val tilgangTrue = Tilgang(
+        true,
+        ""
+    )
+
+    val server = mockTilgangServer(
+        port,
+        tilgangFalse,
+        tilgangTrue
+    )
+
+    private fun mockTilgangServer(
+        port: Int,
+        tilgangFalse: Tilgang,
+        tilgangTrue: Tilgang,
+    ): NettyApplicationEngine {
+        return embeddedServer(
+            factory = Netty,
+            port = port
+        ) {
+            install(ContentNegotiation) {
+                jackson {
+                    registerKotlinModule()
+                    registerModule(JavaTimeModule())
+                    configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                }
+            }
+            routing {
+                get("/syfo-tilgangskontroll/api/tilgang/bruker") {
+                    if (ARBEIDSTAKER_VEILEDER_NO_ACCESS.value == call.parameters["fnr"]) {
+                        call.respond(HttpStatusCode.Forbidden, tilgangFalse)
+                    } else {
+                        call.respond(tilgangTrue)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%t, %d, %-5p, %C:%L, %X{Nav-Callid}] - %.-100000m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="no.nav" level="INFO"/>
+    <logger name="org.apache.kafka" level="WARN" />
+    <logger name="com.zaxxer.hikari.pool" level="INFO" />
+    <logger name="io.ktor.auth" level="TRACE" />
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
For å få testen til å fungere, sender vi nå inn database til PrediksjonApi, i stedet for at den henter den fra databaseModulen selv.

Tilgangskontroll-url settes som miljøvariabel, så vi får riktig host:port i apiet, selv når vi bruker en tilfeldig port.

Endre eksisterende PrediksjonOutputSpek til å bruke nye PrediksjonOutputGenerator.

Legg til logback-test.xml, så vi ikke får exception hver gang vi kjører tester.

Legg til VeilederTilgangskontrollMock, den er kopiert fra isdialogmote, og returnerer true eller false basert på hvilket fnr man sender inn.